### PR TITLE
trivial: Make build work with newer Node version (20+)

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,5 +115,8 @@
     "webpack-hot-middleware": "2.18.2",
     "webpack-livereload-plugin": "0.11.0",
     "webpack-shell-plugin": "0.5.0"
+  },
+  "overrides": {
+    "graceful-fs": "^4.2.11"
   }
 }


### PR DESCRIPTION
Build error we were getting:
```
npm ERR! code 1
npm ERR! path /repos/sane-reports/node_modules/semantic-ui
npm ERR! command failed
npm ERR! command sh -c gulp install
npm ERR! fs.js:****3
npm ERR! } = primordials;
npm ERR!     ^
npm ERR!
npm ERR! ReferenceError: primordials is not defined
npm ERR!     at fs.js:****3:5
npm ERR!     at req_ (/repos/sane-reports/node_modules/natives/index.js:137:5)
npm ERR!     at Object.req [as require] (/repos/sane-reports/node_modules/natives/index.js:5****:10)
npm ERR!     at Object.<anonymous> (/repos/sane-reports/node_modules/vinyl-fs/node_modules/graceful-fs/fs.js:1:37)
npm ERR!     at Module._compile (node:internal/modules/cjs/loader:12****1:1****)
npm ERR!     at Module._extensions..js (node:internal/modules/cjs/loader:1295:10)
npm ERR!     at Module.load (node:internal/modules/cjs/loader:1091:32)
npm ERR!     at Module._load (node:internal/modules/cjs/loader:938:12)
npm ERR!     at Module.require (node:internal/modules/cjs/loader:1115:19)
npm ERR!     at require (node:internal/modules/helpers:130:18)
npm ERR!
npm ERR! Node.js v20.8.1
```